### PR TITLE
prevents showConfiguration from hanging when no options have been set

### DIFF
--- a/src/js/pebble-js-app.js
+++ b/src/js/pebble-js-app.js
@@ -2,12 +2,20 @@ Pebble.addEventListener('ready', function(e) {});
 
 Pebble.addEventListener('showConfiguration', function(e) {
 	var options = JSON.parse(window.localStorage.getItem('options'));
-	console.log('read options: ' + JSON.stringify(options));
-	console.log('showing configuration');
-	var uri = 'https://rawgithub.com/Neal/pebble-authenticator/master/html/configuration.html?' +
-				'timezone=' + encodeURIComponent(options['timezone']) +
-				'&vib_warn=' + encodeURIComponent(options['vib_warn']) +
-				'&vib_renew=' + encodeURIComponent(options['vib_renew']);
+
+	if (options === null) {
+		console.log('options have not been set');
+		console.log('showing configuration');
+		var uri = 'https://rawgithub.com/Neal/pebble-authenticator/master/html/configuration.html';
+	} else {
+		console.log('read options: ' + JSON.stringify(options));
+		console.log('showing configuration');
+		var uri = 'https://rawgithub.com/Neal/pebble-authenticator/master/html/configuration.html?' +
+					'timezone=' + encodeURIComponent(options['timezone']) +
+					'&vib_warn=' + encodeURIComponent(options['vib_warn']) +
+					'&vib_renew=' + encodeURIComponent(options['vib_renew']);
+	}
+
 	Pebble.openURL(uri);
 });
 


### PR DESCRIPTION
When showConfiguration is called on a new install it hangs as the 'options' localStorage item has not been set.

```
[INFO    ] configuration requested
[INFO    ] JS: Authenticator: read options: null
[INFO    ] JS: Authenticator: showing configuration
[INFO    ] Error: Authenticator: TypeError: null is not an object (evaluating 'options['timezone']') at line 10 in pebble-js-app.js
```

This issue is fixed by introducing a check that prevents passing the non-existent settings to the web configuration view.

This patch can be tested by placing the following line inside the showConfiguration call.

```
window.localStorage.removeItem('options');
```
