### PR TITLE
Call configure.py from wscript

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ More info on how to set that up found [here](https://developer.getpebble.com/2/g
 ## Configuration
 
 * Copy `configuration-sample.txt` to `configuration.txt` and add your secrets.
-* Run `./configuration.py`
 
 ## Install
 

--- a/configuration.py
+++ b/configuration.py
@@ -21,40 +21,45 @@ def genKeyLine(code):
 	key_hex = ["0x%02X" % x for x in key_bytes]
 	return '{ ' + ', '.join(key_hex) + ' },'
 
-try:
-	f = open('configuration.txt', 'r')
-except:
-	print 'Unable to open configuration.txt. Cheack README.md for configuration details.'
-	sys.exit(1)
+def generate():
+	try:
+		f = open('configuration.txt', 'r')
+	except:
+		print 'Unable to open configuration.txt. Cheack README.md for configuration details.'
+		sys.exit(1)
+	
+	for line in f:
+		line = line.strip()
+		if line.startswith('#') or not ':' in line: continue
+		key,value = line.split(':')
+		if (key.lower() == 'tz'):
+			time_zone = value
+		else:
+			labels.append(key)
+			secrets.append(genKeyLine(value))
+	f.close()
+	
+	f = open('src/configuration.h', 'w')
+	
+	f.write("#ifndef _CONFIGURATION_H_\n")
+	f.write("#define _CONFIGURATION_H_\n\n")
+	f.write("#define DEFAULT_TIME_ZONE %s\n" % time_zone)
+	f.write("#define NUM_SECRETS %i\n\n" % len(labels))
+	f.write("char otp_labels[NUM_SECRETS][17] = {\n\t")
+	for label in labels:
+		f.write("\"%s\"," % label)
+	f.write("\n};\n\n")
+	f.write("unsigned char otp_keys[NUM_SECRETS][%s] = {\n" % max(lengths))
+	for secret in secrets:
+		f.write("\t%s\n" % secret)
+	f.write("};\n\n")
+	f.write("int otp_sizes[NUM_SECRETS] = {")
+	for length in lengths:
+		f.write("%s," % length)
+	f.write("};\n\n#endif\n")
+	
+	f.close()
 
-for line in f:
-	line = line.strip()
-	if line.startswith('#') or not ':' in line: continue
-	key,value = line.split(':')
-	if (key.lower() == 'tz'):
-		time_zone = value
-	else:
-		labels.append(key)
-		secrets.append(genKeyLine(value))
-f.close()
-
-f = open('src/configuration.h', 'w')
-
-f.write("#ifndef _CONFIGURATION_H_\n")
-f.write("#define _CONFIGURATION_H_\n\n")
-f.write("#define DEFAULT_TIME_ZONE %s\n" % time_zone)
-f.write("#define NUM_SECRETS %i\n\n" % len(labels))
-f.write("char otp_labels[NUM_SECRETS][17] = {\n\t")
-for label in labels:
-	f.write("\"%s\"," % label)
-f.write("\n};\n\n")
-f.write("unsigned char otp_keys[NUM_SECRETS][%s] = {\n" % max(lengths))
-for secret in secrets:
-	f.write("\t%s\n" % secret)
-f.write("};\n\n")
-f.write("int otp_sizes[NUM_SECRETS] = {")
-for length in lengths:
-	f.write("%s," % length)
-f.write("};\n\n#endif\n")
-
-f.close()
+# generate configuration.h if this file is run as the main script
+if __name__ == '__main__':
+	generate()

--- a/wscript
+++ b/wscript
@@ -5,6 +5,8 @@
 # Feel free to customize this to your needs.
 #
 
+import configuration
+
 top = '.'
 out = 'build'
 
@@ -13,6 +15,8 @@ def options(ctx):
 
 def configure(ctx):
 	ctx.load('pebble_sdk')
+
+	configuration.generate()
 
 def build(ctx):
 	ctx.load('pebble_sdk')


### PR DESCRIPTION
Whenever I add a new TOTP key to pebble-authenticator, I always forget to run configure.py.

This patch solves that issue by moving `configure.py`'s "make things happen" code into a function (`configure.generate()`) and adding a call to the function in wscript. `configure.py` will also check if it is being run as the main script and, if it is, will regenerate `configuration.h`.

Whenever `pebble build` is called, `configure.py` is imported and `configure.generate()` is called as a part of the `configure` step.
