### PR TITLE
change versionLabel to 2.0 (fit new major.minor scheme)

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -4,7 +4,7 @@
 	"longName": "Authenticator",
 	"companyName": "Neal",
 	"versionCode": 2,
-	"versionLabel": "2.0.0",
+	"versionLabel": "2.0",
 	"capabilities": [ "configurable" ],
 	"watchapp": {
 		"watchface": false


### PR DESCRIPTION
Pebble-authenticator currently fails to compile due to the newer versions of the Pebble SDK enforcing a minor.minor versioning scheme.

```
Exception: appinfo.json versionLabel format for app revision must be "Major" or "Major.Minor"
```

This patch changes the versionLabel to 2.0 in order to allow it to compile.
