### PR TITLE
Correct issues in configuration.py preventing base32 padding from being done correctly

### DIFF
--- a/configuration.py
+++ b/configuration.py
@@ -10,12 +10,9 @@ time_zone = "0.0"
 
 def genKeyLine(code):
 	secret_key = code.replace(' ','').upper()
-	if len(secret_key) <= 32:
-		key_b32 = secret_key+'='*(32%len(secret_key))
-		key = base64.b32decode(key_b32)
-	else:
-		key_b64 = secret_key+'='*(64%len(secret_key))
-		key = base64.b32decode(key_b64)
+        pad = 0 if (len(secret_key) % 8) == 0 else 8 - (len(secret_key) % 8)
+        key_enc = secret_key + ('='*pad)
+        key = base64.b32decode(key_enc)
 	key_bytes = map(ord,key)
 	lengths.append(len(key_bytes))
 	key_hex = ["0x%02X" % x for x in key_bytes]


### PR DESCRIPTION
When presented with TOTP secrets which are 26 characters long, the original configuration.py would choke and b32decode would fail with incorrect padding; this fixes padding issues by ensuring that the final length of the string is divisible by 8, as all base32 strings should have between 0 and 7 padding characters.