### PR TITLE
Update to newest SDK.

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -1,27 +1,35 @@
 {
-	"uuid": "011046be-c0c1-464d-af81-381b937447cd",
-	"shortName": "Authenticator",
-	"longName": "Authenticator",
-	"companyName": "Neal",
-	"versionCode": 2,
-	"versionLabel": "2.0",
-	"capabilities": [ "configurable" ],
-	"watchapp": {
-		"watchface": false
-	},
-	"appKeys": {
-		"timezone": 0,
-		"vib_warn": 1,
-		"vib_renew": 2
-	},
-	"resources": {
-		"media": [
-			{
-				"menuIcon": true,
-				"type": "png",
-				"name": "IMAGE_MENU_ICON",
-				"file": "images/twostep_icon.png"
-			}
-		]
-	}
+  "uuid": "011046be-c0c1-464d-af81-381b937447cd",
+  "shortName": "Authenticator",
+  "longName": "Authenticator",
+  "companyName": "Neal",
+  "versionCode": 2,
+  "versionLabel": "2.0",
+  "capabilities": [
+    "configurable"
+  ],
+  "watchapp": {
+    "watchface": false
+  },
+  "appKeys": {
+    "timezone": 0,
+    "vib_warn": 1,
+    "vib_renew": 2
+  },
+  "resources": {
+    "media": [
+      {
+        "menuIcon": true,
+        "type": "png",
+        "name": "IMAGE_MENU_ICON",
+        "file": "images/twostep_icon.png"
+      }
+    ]
+  },
+  "targetPlatforms": [
+    "aplite",
+    "basalt",
+    "chalk"
+  ],
+  "sdkVersion": "3"
 }

--- a/wscript
+++ b/wscript
@@ -6,23 +6,38 @@
 #
 
 import configuration
+import os.path
 
 top = '.'
 out = 'build'
 
 def options(ctx):
-	ctx.load('pebble_sdk')
+    ctx.load('pebble_sdk')
 
 def configure(ctx):
-	ctx.load('pebble_sdk')
-
-	configuration.generate()
+    ctx.load('pebble_sdk')
+    configuration.generate()
 
 def build(ctx):
-	ctx.load('pebble_sdk')
+    ctx.load('pebble_sdk')
 
-	ctx.pbl_program(source=ctx.path.ant_glob('src/**/*.c'),
-					target='pebble-app.elf')
+    build_worker = os.path.exists('worker_src')
+    binaries = []
 
-	ctx.pbl_bundle(elf='pebble-app.elf',
-					js=ctx.path.ant_glob('src/js/**/*.js'))
+    for p in ctx.env.TARGET_PLATFORMS:
+        ctx.set_env(ctx.all_envs[p])
+        ctx.set_group(ctx.env.PLATFORM_NAME)
+        app_elf='{}/pebble-app.elf'.format(ctx.env.BUILD_DIR)
+        ctx.pbl_program(source=ctx.path.ant_glob('src/**/*.c'),
+        target=app_elf)
+
+        if build_worker:
+            worker_elf='{}/pebble-worker.elf'.format(ctx.env.BUILD_DIR)
+            binaries.append({'platform': p, 'app_elf': app_elf, 'worker_elf': worker_elf})
+            ctx.pbl_worker(source=ctx.path.ant_glob('worker_src/**/*.c'),
+            target=worker_elf)
+        else:
+            binaries.append({'platform': p, 'app_elf': app_elf})
+
+    ctx.set_group('bundle')
+    ctx.pbl_bundle(binaries=binaries, js=ctx.path.ant_glob('src/js/**/*.js'))


### PR DESCRIPTION
Thanks for this project! Definitely prefer this to something which thinks it's a good idea to backup the keys to the cloud... (someone must've missed the idea of 2FA)

However it seems it's outdated:

```
$ pebble build
This project is outdated (try 'pebble convert-project').

$ pebble convert-project
WARNING: You had modified your wscript and those changes will be lost.
Saving your old wscript in wscript.backup.
Generating new 3.x wscript
'distclean' finished successfully (0.000s)
Project successfully converted!
```

This re-adds the wscript modifications on top of what pebble convert-project did.
